### PR TITLE
fix: update version to publish doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsmrs"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 authors = ["LSH <github@lsh.tech>"]
 description = "Simple FSM (Final state machine) library wrtting in rust"
@@ -11,3 +11,4 @@ name = "fsmrs"
 path = "src/lib.rs"
 
 [dependencies]
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-fsmrs = "0.1.0"
+fsmrs = "0.1.2"
 ```
 
 ## Changelog


### PR DESCRIPTION
# Fix: Update Version to Publish Documentation

## Description
This PR updates the version to ensure that the documentation is correctly published. It aligns the version number with the latest changes for proper documentation generation.

## Changes
- Updated version in configuration files to trigger documentation publishing.

## How to Verify
1. Check that the version has been updated in the relevant configuration files.
2. Ensure that the documentation is correctly published with the updated version.
